### PR TITLE
Add refinements for the Time class to support times as loggable values.

### DIFF
--- a/lib/green_log/core_refinements.rb
+++ b/lib/green_log/core_refinements.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "time"
+
 module GreenLog
 
   # Refine
@@ -64,6 +66,14 @@ module GreenLog
 
       def to_loggable_value
         self
+      end
+
+    end
+
+    refine ::Time do
+
+      def to_loggable_value
+        iso8601.freeze
       end
 
     end

--- a/spec/green_log/core_refinements_spec.rb
+++ b/spec/green_log/core_refinements_spec.rb
@@ -95,4 +95,20 @@ RSpec.describe GreenLog::CoreRefinements do
 
   end
 
+  describe Time do
+
+    describe "#to_loggable_value" do
+
+      it "returns the time in ISO8601 format with the time zone preserved" do
+        original = Time.new(2020, 1, 1, 12, 0o0, 0o0, "+10:00")
+        result = original.to_loggable_value
+        expect(result).to eq("2020-01-01T12:00:00+10:00")
+        expect(result).to be_frozen
+        expect(original).to_not be_frozen
+      end
+
+    end
+
+  end
+
 end


### PR DESCRIPTION
For context, we want to log an entry where the extra data is a hash that includes a Time object as one of the hash values. We think it's reasonable to support this for Time objects as there's an obvious way to serialize them.

Co-Authored-By: Brendan Weibrecht <brendan@weibrecht.net.au>